### PR TITLE
Fix typespec

### DIFF
--- a/lib/opentelemetry_function.ex
+++ b/lib/opentelemetry_function.ex
@@ -43,7 +43,7 @@ defmodule OpentelemetryFunction do
   """
   def wrap(fun_or_mfa, span_name \\ "Function.wrap")
 
-  @spec wrap(fun(), binary()) :: fun()
+  @spec wrap(fun, binary) :: fun
   Enum.each(0..9, fn arity ->
     args = for _ <- 1..arity, arity > 0, do: Macro.unique_var(:arg, __MODULE__)
 
@@ -64,7 +64,7 @@ defmodule OpentelemetryFunction do
     end
   end)
 
-  @spec wrap(mfa(), binary()) :: fun()
+  @spec wrap({module, atom, [term]}, binary()) :: fun
   def wrap({mod, fun, args}, span_name) do
     span_ctx = OpenTelemetry.Tracer.start_span(span_name)
     ctx = OpenTelemetry.Ctx.get_current()

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule OpentelemetryFunction.MixProject do
   def project do
     [
       app: :opentelemetry_function,
-      version: "0.1.0-rc.1",
+      version: "0.1.0-rc.2",
       elixir: "~> 1.11",
       start_permanent: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
I thought mfa captures {module, function, args}, but it actually refers to
{module, function, arity} which is a bit different. This is also how it's
defined [in elixir code][1]. Also removed unnecessary parantheses.

[1]: https://github.com/elixir-lang/elixir/blob/dc753d6a05aef8844acc60d7d1b1107439489210/lib/elixir/lib/task.ex#L317