### PR TITLE
Fix ExDoc and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:opentelemetry_function, "~> 0.1.0-rc.1"}
+    {:opentelemetry_function, "~> 0.1"}
   ]
 end
 ```

--- a/lib/opentelemetry_function.ex
+++ b/lib/opentelemetry_function.ex
@@ -38,7 +38,7 @@ defmodule OpentelemetryFunction do
       :jobs.enqueue(:tasks_queue, {mod, fun, args})
 
       # After
-      wrapped_fun = OpenTelemetry.Function.wrap({mod, fun, args})
+      wrapped_fun = OpentelemetryFunction.wrap({mod, fun, args})
       :jobs.enqueue(:tasks_queue, wrapped_fun)
   """
   def wrap(fun_or_mfa, span_name \\ "Function.wrap")


### PR DESCRIPTION
There was a typo in one place and also we can use non-rc version now.