### PR TITLE
Fix publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,14 +5,31 @@ on:
     branches:
       - master
 
+env:
+  elixir: '1.19'
+  otp: '28.4'
+
 jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
       - name: Check out
-        uses: actions/checkout@v2
-
+        uses: actions/checkout@v6
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: ${{env.otp}}
+          elixir-version: ${{env.elixir}}
+      - uses: actions/cache@v5
+        with:
+          path: |
+            deps
+            _build
+          key: ${{ runner.os }}-mix-${{env.elixir}}-${{env.otp}}-${{ hashFiles('mix.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-mix-${{env.elixir}}-${{env.otp}}-
+      - name: Run mix deps.get
+        run: mix deps.get
       - name: Publish package to hex.pm
-        uses: wesleimp/action-publish-hex@ae719f0fead451221d2ca0127c0aae70c5f90b4c
+        run: mix hex.publish --yes
         env:
           HEX_API_KEY: ${{ secrets.HEX_API_KEY }}


### PR DESCRIPTION
The workflow was using an action for the publish which uses an
hard-coded, old (1.11) version of Elixir, which now fails with the
following error:
```
** (Mix) You're trying to run :opentelemetry_function on Elixir v1.11.3 but it has declared in its mix.exs file it supports only Elixir ~> 1.12
```

Because the publishing itself is essentially just a `mix hex.publish`
call, then this workflow now uses a similar structure to the CI workflow
to set everything up and call the publish function, avoiding the need
for using third-party action for the publish.
