### PR TITLE
Add Snyk Elixir security scan workflow

### DIFF
--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -1,0 +1,20 @@
+name: Snyk Elixir Security Scan
+
+on:
+  pull_request:
+  merge_group:
+  push:
+    branches:
+      - master
+  schedule:
+    - cron: '57 3 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  security-scan:
+    uses: salemove/glia-security-workflows/.github/workflows/elixir-snyk-security-scan.yaml@master
+    secrets:
+      SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}


### PR DESCRIPTION
## Why

This repository is categorised `production_library` in DevHub, which requires Snyk coverage. Elixir has no Snyk SCM support — importing through the GitHub Cloud App produces no projects — so the CLI workflow is the only path that scans `mix.lock` (hex dependencies).

Docs: [Snyk for Elixir projects](https://internal-docs.at.samo.io/security-documentation/docs/snyk/elixir-projects.html)

## What this does

- `pull_request` / `merge_group`: tests the dependency tree the change would introduce
- `push` to `master`: (re-)registers the repo's hex projects in Snyk org `glia-devexp` (via the `SNYK_ORGANIZATION_SLUG` Actions variable, already set on this repository)
- weekly `schedule` + `workflow_dispatch`: keeps the snapshot fresh when the repository is quiet

**Merging this PR is what creates the Snyk projects** — the push run performs the `snyk monitor` registration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)