### PR TITLE
Pin the CI and publish actions to SHAs and scope their tokens

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions:
+  contents: read
+
 jobs:
   elixir:
     name: OTP ${{matrix.pair.otp_version}} / Elixir ${{matrix.pair.elixir}}
@@ -21,12 +24,14 @@ jobs:
               otp: '28.4'
             lint: lint
     steps:
-      - uses: actions/checkout@v6
-      - uses: erlef/setup-beam@v1
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
+        with:
+          persist-credentials: false
+      - uses: erlef/setup-beam@54075bcc5e249e4758d363f27d099f55d843f124
         with:
           otp-version: ${{matrix.pair.otp}}
           elixir-version: ${{matrix.pair.elixir}}
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25
         with:
           path: |
             deps

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,17 +9,22 @@ env:
   elixir: '1.19'
   otp: '28.4'
 
+permissions:
+  contents: read
+
 jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
       - name: Check out
-        uses: actions/checkout@v6
-      - uses: erlef/setup-beam@v1
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
+        with:
+          persist-credentials: false
+      - uses: erlef/setup-beam@54075bcc5e249e4758d363f27d099f55d843f124
         with:
           otp-version: ${{env.otp}}
           elixir-version: ${{env.elixir}}
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25
         with:
           path: |
             deps


### PR DESCRIPTION
zizmor reported ten findings on this repository, all of them in ci.yml and
publish.yml - security.yaml was already clean:

  6x high  unpinned-uses          actions/checkout@v6, erlef/setup-beam@v1,
                                  actions/cache@v5, in both workflows
  2x high  excessive-permissions  neither workflow declares `permissions:`,
                                  so both run on the default broad token
  2x low   artipacked             checkout leaves its credential on disk

WHAT THE SHAs ARE

Each ref is pinned to the commit its floating tag pointed at when this was
written, so the same code runs before and after - this freezes behaviour, it
does not upgrade anything:

  d23441a48e516b6c34aea4fa41551a30e30af803  actions/checkout    v6.1.0
  54075bcc5e249e4758d363f27d099f55d843f124  erlef/setup-beam    v1.24.1
  caa296126883cff596d87d8935842f9db880ef25  actions/cache       v5.1.0

Recorded here rather than as `# vX.Y.Z` trailers, so the workflows stay
comment-free and match security.yaml, which pins bare SHAs already. A tag can
be moved under you; a SHA cannot, and that is the whole point of the change.

Separately worth knowing, and deliberately NOT bundled here: checkout and
cache are each a major version behind (v7 and v6 are out). Upgrading them is
a behaviour change and belongs in its own PR.

WHY THESE PERMISSIONS

Both workflows get `permissions: contents: read`, which is everything either
one needs:

  ci.yml       only reads the repo and runs the suite. It publishes nothing
               and writes nothing back.
  publish.yml  ships to hex.pm authenticated by HEX_API_KEY, never back to
               this repository, so the GitHub token only reads the checkout.

`persist-credentials: false` on both checkouts for the same reason - nothing
downstream pushes, so the credential does not need to outlive the step or end
up inside an uploaded artifact.

WHAT IS NOT TOUCHED

security.yaml stays. It is the Elixir Snyk scan, and per the Snyk
repository-setup guide the Elixir workflow is the one supported path - the
GitHub Cloud App does not cover hex. Only the Go, npm, pip and rubygems scan
workflows are deprecated, and this repository has none of them.

zizmor is clean after this change, and both CI matrix legs pass.

